### PR TITLE
Fix marker image upload functionality

### DIFF
--- a/frontend/src/views/MarkersView.vue
+++ b/frontend/src/views/MarkersView.vue
@@ -84,7 +84,8 @@
                   label="画像ファイル"
                   accept="image/*"
                   prepend-icon="mdi-camera"
-                  @change="onFileChange"
+                  @update:model-value="onFileChange"
+                  clearable
                 ></v-file-input>
               </v-col>
               <v-col cols="12" md="6">
@@ -234,8 +235,16 @@ const close = () => {
   }, 300)
 }
 
-const onFileChange = (files: File[]) => {
-  selectedFile.value = files
+const onFileChange = (files: File[] | File | null) => {
+  if (files) {
+    if (Array.isArray(files)) {
+      selectedFile.value = files
+    } else {
+      selectedFile.value = [files]
+    }
+  } else {
+    selectedFile.value = []
+  }
 }
 
 const save = async () => {
@@ -243,7 +252,7 @@ const save = async () => {
   try {
     let filePath = editedItem.value.filePath || ''
     
-    if (selectedFile.value.length > 0) {
+    if (selectedFile.value && selectedFile.value.length > 0) {
       const uploadResponse = await uploadApi.uploadFile(selectedFile.value[0])
       filePath = uploadResponse.data.filePath
     }


### PR DESCRIPTION
- Fix v-file-input binding by changing @change to @update:model-value
- Improve file handling to support both File and File[] types
- Add clearable attribute to v-file-input component
- Resolves issue where selectedFile reactive variable wasn't populated
- Image upload now works end-to-end with successful POST /api/upload requests
- Uploaded files are correctly saved to uploads/ directory

Tested with test-marker-image.png - upload successful with filePath: /uploads/1753260641562_test-marker-image.png